### PR TITLE
feature: add blanket implementation of `DeserializeSeeded` for any type that implements `serde::Deserialize`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -59,6 +59,7 @@ version = "0.1.0"
 dependencies = [
  "serde",
  "serde-seeded-derive",
+ "static_assertions",
 ]
 
 [[package]]
@@ -82,6 +83,12 @@ dependencies = [
  "quote",
  "syn 2.0.90",
 ]
+
+[[package]]
+name = "static_assertions"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a2eb9349b6444b326872e140eb1cf5e7c522154d69e7a0ffb0fb81c06b37543f"
 
 [[package]]
 name = "syn"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -38,3 +38,6 @@ derive = ["serde-seeded-derive"]
 [dependencies]
 serde = "1.0.210"
 serde-seeded-derive = { version = "0.1.0", path = "derive", optional = true }
+
+[dev-dependencies]
+static_assertions = "1.1.0"

--- a/tests/derive_de.rs
+++ b/tests/derive_de.rs
@@ -46,3 +46,23 @@ pub enum Bar {
 	Struct { foo: Seeded<u32>, bar: Seeded<bool> },
 }
 static_assertions::assert_impl_all!(Bar: DeserializeSeeded<'static, Seed>);
+
+struct Foo;
+
+impl<'de> serde::Deserialize<'de> for Foo {
+	fn deserialize<D>(_deserializer: D) -> Result<Self, D::Error>
+	where
+		D: serde::Deserializer<'de>,
+	{
+		unimplemented!()
+	}
+}
+
+#[derive(DeserializeSeeded)]
+#[seeded(de(seed(Seed)))]
+pub struct HybridStruct {
+	foo: Seeded<bool>,
+	bar: Seeded<u32>,
+	text: Foo,
+}
+static_assertions::assert_impl_all!(HybridStruct: DeserializeSeeded<'static, Seed>);

--- a/tests/derive_de.rs
+++ b/tests/derive_de.rs
@@ -17,14 +17,17 @@ impl<'de, T> DeserializeSeeded<'de, Seed> for Seeded<T> {
 #[derive(DeserializeSeeded)]
 #[seeded(de(seed(Seed)))]
 pub struct Unit;
+static_assertions::assert_impl_all!(Unit: DeserializeSeeded<'static, Seed>);
 
 #[derive(DeserializeSeeded)]
 #[seeded(de(seed(Seed)))]
 pub struct Newtype(Seeded<u32>);
+static_assertions::assert_impl_all!(Newtype: DeserializeSeeded<'static, Seed>);
 
 #[derive(DeserializeSeeded)]
 #[seeded(de(seed(Seed)))]
 pub struct Tuple(Seeded<u32>, Seeded<bool>);
+static_assertions::assert_impl_all!(Tuple: DeserializeSeeded<'static, Seed>);
 
 #[derive(DeserializeSeeded)]
 #[seeded(de(seed(Seed)))]
@@ -32,6 +35,7 @@ pub struct Struct {
 	foo: Seeded<bool>,
 	bar: Seeded<u32>,
 }
+static_assertions::assert_impl_all!(Struct: DeserializeSeeded<'static, Seed>);
 
 #[derive(DeserializeSeeded)]
 #[seeded(de(seed(Seed)))]
@@ -41,3 +45,4 @@ pub enum Bar {
 	Tuple(Seeded<u32>, Seeded<bool>),
 	Struct { foo: Seeded<u32>, bar: Seeded<bool> },
 }
+static_assertions::assert_impl_all!(Bar: DeserializeSeeded<'static, Seed>);

--- a/tests/derive_ser.rs
+++ b/tests/derive_ser.rs
@@ -17,14 +17,17 @@ impl<'de, T> SerializeSeeded<Seed> for Seeded<T> {
 #[derive(SerializeSeeded)]
 #[seeded(ser(seed(Seed)))]
 pub struct Unit;
+static_assertions::assert_impl_all!(Unit: SerializeSeeded<Seed>);
 
 #[derive(SerializeSeeded)]
 #[seeded(ser(seed(Seed)))]
 pub struct Newtype(Seeded<u32>);
+static_assertions::assert_impl_all!(Newtype: SerializeSeeded<Seed>);
 
 #[derive(SerializeSeeded)]
 #[seeded(ser(seed(Seed)))]
 pub struct Tuple(Seeded<u32>, Seeded<bool>);
+static_assertions::assert_impl_all!(Tuple: SerializeSeeded<Seed>);
 
 #[derive(SerializeSeeded)]
 #[seeded(ser(seed(Seed)))]
@@ -32,6 +35,7 @@ pub struct Struct {
 	foo: Seeded<bool>,
 	bar: Seeded<u32>,
 }
+static_assertions::assert_impl_all!(Struct: SerializeSeeded<Seed>);
 
 #[derive(SerializeSeeded)]
 #[seeded(ser(seed(Seed)))]
@@ -45,3 +49,4 @@ pub enum Bar {
 		bar: Option<Seeded<bool>>,
 	},
 }
+static_assertions::assert_impl_all!(Bar: SerializeSeeded<Seed>);

--- a/tests/derive_ser.rs
+++ b/tests/derive_ser.rs
@@ -50,3 +50,12 @@ pub enum Bar {
 	},
 }
 static_assertions::assert_impl_all!(Bar: SerializeSeeded<Seed>);
+
+#[derive(SerializeSeeded)]
+#[seeded(ser(seed(Seed)))]
+pub struct HybridStruct {
+	foo: Seeded<bool>,
+	bar: Seeded<u32>,
+	text: String,
+}
+static_assertions::assert_impl_all!(HybridStruct: SerializeSeeded<Seed>);


### PR DESCRIPTION
From what I can gather, most applications of seed deserializing only need the seeded information for a subset of the fields.
    
Having to have every one of these fields' types be wrapped in a newtype instead of their natural representation is non-ideal.

This makes the use of the Seeded<T> wrapper optional for fields which do not need seed handling.

This pull requests proposed a blanked implementation of `DeserializedSeed` when `serde::Deserialize` is present. However, due to the orphan rule, this also means that **we break existing code that uses the implementation for containers (`Option`, `BTreeMap` ...)**. This is not ideal, also leading to some additional churn when using this library.

This relies on #25 for the use of `static_assertions` in tests